### PR TITLE
fix: deploy confirmation prompt is declined immediately on a TTY

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gas-app-kit",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Environment registry, build orchestration, deployment and rollback for Google Apps Script projects",
   "type": "module",
   "license": "MIT",

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -113,9 +113,16 @@ function promptYesNo(question: string): boolean {
   const buffer = Buffer.alloc(8)
   let bytes: number
   try {
-    bytes = fs.readSync(0, buffer, 0, buffer.length, null)
+    // Not fd 0: touching `process.stdin` above put it in non-blocking mode, so
+    // `readSync(0)` throws EAGAIN before the user can type. `/dev/tty` blocks.
+    const tty = fs.openSync('/dev/tty', 'r')
+    try {
+      bytes = fs.readSync(tty, buffer, 0, buffer.length, null)
+    } finally {
+      fs.closeSync(tty)
+    }
   } catch {
-    // No readable stdin is a decline, not a crash.
+    // No readable terminal is a decline, not a crash.
     return false
   }
   return /^y/i.test(buffer.toString('utf-8', 0, bytes).trim())


### PR DESCRIPTION
Closes #4

`promptYesNo` read fd 0 after `process.stdin.isTTY` had put it in non-blocking mode, so `fs.readSync` threw `EAGAIN` and the deploy was declined before the user could answer. Read `/dev/tty` instead, which blocks until input arrives.

Verified in a pty against a real project: with no input the prompt waits; sending `n` prints "declined" only then. Unit tests (149) and typecheck pass.

Also bumps the version to 0.1.3 for the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gqdd5NZAGYUaDJgA3caWax